### PR TITLE
set event channel queues to auto delete.

### DIFF
--- a/lib/isono/node_modules/event_channel.rb
+++ b/lib/isono/node_modules/event_channel.rb
@@ -55,7 +55,7 @@ module Isono
       end
       
       def subscribe(evname, sender='#', receiver_id=node.node_id, &blk)
-        @amq.queue("#{evname}-#{receiver_id}", {:exclusive=>true}).bind(
+        @amq.queue("#{evname}-#{receiver_id}",{:auto_delete=>true}).bind(
                      AMQP_EXCHANGE, :key=>"#{evname}.#{sender}"
                      ).subscribe { |data|
           data = Serializer.instance.unmarshal(data)
@@ -73,7 +73,7 @@ module Isono
       
       def unsubscribe(evname, receiver_id=node.node_id)
         EventMachine.schedule {
-          q = @amq.queue("#{evname}-#{receiver_id}")
+          q = @amq.queue("#{evname}-#{receiver_id}",{:auto_delete=>true})
           q.unsubscribe
         }
       end


### PR DESCRIPTION
Set event channel queues to auto delete so you can dynamically subscribe and unsubscribe to events.
