### PR TITLE
Fix response received already

### DIFF
--- a/isono.gemspec
+++ b/isono.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "isono"
-  s.version = "0.2.19"
+  s.version = "0.2.20"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["axsh Ltd.", "Masahiro Fujiwara"]

--- a/lib/isono/node_modules/rpc_channel.rb
+++ b/lib/isono/node_modules/rpc_channel.rb
@@ -342,6 +342,8 @@ module Isono
         attr_reader :error_cb, :success_cb, :progress_cb
         attr_reader :state
 
+        include Isono::Logger
+
         def initialize(endpoint, command, args)
           super({:request=>{
                     :endpoint=> endpoint,
@@ -432,6 +434,7 @@ module Isono
         module RequestSynchronize
           def self.extended(mod)
             raise TypeError, "This module is applicable only for RequestContext" unless mod.is_a?(RequestContext)
+
             # overwrite callbacks
             mod.instance_eval {
               @q = ::Queue.new
@@ -448,6 +451,11 @@ module Isono
           public
           def wait()
             raise "wait() has to be called at outside of the EventMachine's main loop." if EventMachine.reactor_thread?
+            if state == :done && @q.empty?
+              logger.warn "Remote procedure call state is 'done' and response queue is empty. " +
+                          "May be waiting forever for a response. Endpoint: '%s' Command: '%s'" %
+                          [endpoint, command]
+            end
 
             r = @q.deq
 

--- a/lib/isono/node_modules/rpc_channel.rb
+++ b/lib/isono/node_modules/rpc_channel.rb
@@ -447,7 +447,6 @@ module Isono
 
           public
           def wait()
-            raise "response was received already." if state == :done
             raise "wait() has to be called at outside of the EventMachine's main loop." if EventMachine.reactor_thread?
 
             r = @q.deq

--- a/lib/isono/node_modules/rpc_channel.rb
+++ b/lib/isono/node_modules/rpc_channel.rb
@@ -105,7 +105,7 @@ module Isono
       attr_reader :amq
 
       # Make a RPC request to an endpoint.
-      # 
+      #
       # @param [String] endpoint
       # @param [String] command
       # @param [Array] args
@@ -125,7 +125,7 @@ module Isono
       #   }
       #
       # @example setup request context and do wait().
-      #   Note that callbacks are 
+      #   Note that callbacks are
       #   rpc.request('endpoint1', 'func1', xxxx) { |req|
       #     # send new attribute
       #     req.request[:xxxx] = "sdfsdf"
@@ -133,7 +133,7 @@ module Isono
       #     req.synchronize
       #   }.wait # request() get back the altered RequestCotenxt that has wait().
       #
-      # @example Create async oneshot call. (do not expect response) 
+      # @example Create async oneshot call. (do not expect response)
       #   rpc.request('endpoint1', 'func1') { |req|
       #     req.oneshot = true
       #   }
@@ -141,7 +141,7 @@ module Isono
         req = RequestContext.new(endpoint, command, args)
         # the block is to setup the request context prior to sending.
         if blk
-          # async 
+          # async
           r = blk.call(req)
           req = r if r.is_a?(RequestContext)
           send_request(req)
@@ -165,7 +165,7 @@ module Isono
       def register_endpoint(endpoint, app, opts={})
         raise TypeError unless app.respond_to?(:call)
         opts = {:exclusive=>true, :prefetch=>1}.merge(opts)
-        
+
         # create receive queue for new RPC endpoint.
         endpoint_proc = proc { |header, data|
 
@@ -188,7 +188,7 @@ module Isono
           end
         }
 
-        
+
         EventMachine.schedule {
           ch = node.create_channel
 
@@ -215,7 +215,7 @@ module Isono
       end
 
       # Unregister endpoint.
-      # 
+      #
       # @param [String] endpoint endpoint name to be removed
       def unregister_endpoint(endpoint)
         if @endpoints.has_key?(endpoint)
@@ -228,7 +228,7 @@ module Isono
           }
         end
       end
-      
+
       private
       def endpoint_queue_name(ns)
         "isono.rpc.endpoint.#{ns}"
@@ -253,9 +253,9 @@ module Isono
           # set default timeout if no one updated the initial value.
           req.timeout_sec = config_section.timeout_sec
         end
-                
+
         req.process_event(:on_ready)
-        
+
         EventMachine.schedule {
           @stats[:total_request_count] += 1
           if @stats[:peak_wait_response_size] < @active_requests.size
@@ -281,7 +281,7 @@ module Isono
 
       class ResponseContext
         attr_reader :header
-        
+
         def initialize(exchange, header)
           @responded = false
           @exchange = exchange
@@ -355,7 +355,7 @@ module Isono
                   :completed_at => nil,
                   :complete_status => nil,
                 })
-          
+
           @success_cb = nil
           @progress_cb = nil
           @error_cb = nil
@@ -435,7 +435,7 @@ module Isono
             # overwrite callbacks
             mod.instance_eval {
               @q = ::Queue.new
-              
+
               on_success { |r|
                 @q << [:success, r]
               }
@@ -449,9 +449,9 @@ module Isono
           def wait()
             raise "response was received already." if state == :done
             raise "wait() has to be called at outside of the EventMachine's main loop." if EventMachine.reactor_thread?
-            
+
             r = @q.deq
-            
+
             case r[0]
             when :success
               r[1]
@@ -460,9 +460,9 @@ module Isono
             end
           end
         end
-        
+
       end
-      
+
     end
   end
 end


### PR DESCRIPTION
The *"Response was received already"* race condition has been a thorn in our side for a while. The code responsible for it all is here

https://github.com/axsh/isono/blob/master/lib/isono/node_modules/rpc_channel.rb#L152-L153

The error would occur when a remote procedure call finished before the `wait` method was called. The first thing the wait method does is [check if the request state is `:done`](https://github.com/axsh/isono/blob/master/lib/isono/node_modules/rpc_channel.rb#L450) and then raises the error.

This check was probably put in place as a safety for people calling the `wait` method twice on the same remote procedure call. In that case it would wait forever for the call's result to enter the queue. However, since we cannot guarantee that the call won't finish before `wait` is called the first time, this check needs to be removed.

**Edit:** As requested by @unakatsuo, I put a logger WARN message in its place.